### PR TITLE
Improve evil team bluff coordination

### DIFF
--- a/COMMUNICATION_FORMAT.md
+++ b/COMMUNICATION_FORMAT.md
@@ -17,7 +17,19 @@ Two common message types are used:
   {"public": {"night_results": [{"night": 2, "player1": "Alice", "player2": "Bob", "ping": False}]}}
   ```
 
-Additional keys may be present for special messages (e.g. the Demon privately sending `{"bluffs": ["Chef", "Mayor", "Empath"]}` to its minions).
+Additional keys may be present for special messages. Common examples include:
+  - The Demon privately sending bluffs to minions:
+    ```python
+    {"bluffs": ["Chef", "Mayor", "Empath"]}
+    ```
+  - A full bluff plan mapping each evil player to a specific claim:
+    ```python
+    {"bluff_plan": {"Evil1": "Chef", "Evil2": "Slayer"}, "assigned_bluff": "Chef"}
+    ```
+  - Public confirmations of a teammate's claim:
+    ```python
+    {"confirm": [{"player": "Evil2", "role": "Slayer"}]}
+    ```
 
 Below is a summary of the information each role places in its own `memory` during play. These same structures appear in messages when that information is shared.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This project is an experimental AI designed to:
 - Probabilistic reasoning and deduction engine.
 - Basic game simulation and storyteller AI logic.
 - (WIP) Player nomination/voting and star-passing mechanics.
+- Coordinated bluffing system for evil players with public confirmations.
 
 ## Limitations & To-Do
 - File structure is under heavy development; expect refactoring soon.


### PR DESCRIPTION
## Summary
- assign a specific bluff to each evil player at game start and store a full bluff plan
- update evil player AI to prefer assigned bluffs and generate fake info that can reference teammates
- allow evil players to publicly confirm allies once their claims appear
- document new message types and mention improved bluff coordination in README

## Testing
- `python -m py_compile game.py evil_player_controller.py good_player_controller.py deduction_engine.py simulate_games.py`

------
https://chatgpt.com/codex/tasks/task_e_688279fa4d308327b92dacd70c2c965e